### PR TITLE
Remove async-trait dependency requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.6"
 edition = "2021"
 authors = ["mbecker20 <becker.maxh@gmail.com>"]
 license = "GPL-3.0-or-later"
+repository = "https://github.com/mbecker20/resolver_api"
 
 [package]
 name = "resolver_api"
@@ -14,6 +15,7 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -54,9 +54,11 @@ pub fn derive_resolver(input: TokenStream) -> TokenStream {
   };
 
   quote! {
-    #[async_trait::async_trait]
     impl resolver_api::Resolver<#ident, #args> for #target {
-      async fn resolve_request(&self, request: #ident, args: #args) -> anyhow::Result<String> {
+      async fn resolve_request<'a>(&'a self, request: #ident, args: #args) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send + 'a>
+        where
+          Self: Sync + 'a
+      {
         match request {
           #(#ident::#std_variant(req) => self.resolve_response(req, args).await,)*
           #(#ident::#to_string_variant(req) => self.resolve_to_string(req, args).await,)*


### PR DESCRIPTION
Derive macro forces importing packages to also directly depend on `async-trait`.