### PR TITLE
Restore `Response::Error`

### DIFF
--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use axum::{routing::post, Extension, Json, Router};
+use axum::{response::IntoResponse, routing::post, Extension, Json, Router};
 use requests::Request;
 use resolver_api::Resolve;
 
@@ -24,7 +24,10 @@ async fn main() -> anyhow::Result<()> {
       "/",
       post(
         |state: Extension<Arc<State>>, Json(req): Json<Request>| async move {
-          req.resolve(&state).await.response
+          match req.resolve(&state).await {
+            Ok(res) => res.response,
+            Err(err) => err.into_response(),
+          }
         },
       ),
     )

--- a/examples/axum/src/requests/get_num.rs
+++ b/examples/axum/src/requests/get_num.rs
@@ -1,4 +1,4 @@
-use axum::Json;
+use axum::{http::StatusCode, Json};
 use resolver_api::Resolve;
 use serde::{Deserialize, Serialize};
 
@@ -6,6 +6,7 @@ use crate::State;
 
 #[derive(Deserialize, Debug, Resolve)]
 #[response(Json<GetNumResponse>)]
+#[error(StatusCode)]
 pub struct GetNum {}
 
 #[derive(Serialize, Debug)]
@@ -14,7 +15,7 @@ pub struct GetNumResponse {
 }
 
 impl Resolve<State> for GetNum {
-  async fn resolve(self, state: &State) -> Json<GetNumResponse> {
-    Json(GetNumResponse { num: state.num })
+  async fn resolve(self, state: &State) -> Result<Json<GetNumResponse>, StatusCode> {
+    Ok(Json(GetNumResponse { num: state.num }))
   }
 }

--- a/examples/axum/src/requests/get_string.rs
+++ b/examples/axum/src/requests/get_string.rs
@@ -1,3 +1,4 @@
+use axum::http::StatusCode;
 use axum_extra::{headers::ContentType, TypedHeader};
 use resolver_api::Resolve;
 use serde::Deserialize;
@@ -6,11 +7,12 @@ use crate::State;
 
 #[derive(Deserialize, Debug, Resolve)]
 #[response((TypedHeader<ContentType>, String))]
+#[error(StatusCode)]
 pub struct GetString {}
 
 impl Resolve<State> for GetString {
-  async fn resolve(self, state: &State) -> (TypedHeader<ContentType>, String) {
+  async fn resolve(self, state: &State) -> Result<(TypedHeader<ContentType>, String), Self::Error> {
     // This could be pulled out of a cache of serialized responses
-    (TypedHeader(ContentType::json()), state.json_string.clone())
+    Ok((TypedHeader(ContentType::json()), state.json_string.clone()))
   }
 }

--- a/examples/axum/src/requests/health_check.rs
+++ b/examples/axum/src/requests/health_check.rs
@@ -1,4 +1,4 @@
-use axum::Json;
+use axum::{http::StatusCode, Json};
 use resolver_api::Resolve;
 use serde::{Deserialize, Serialize};
 
@@ -6,13 +6,14 @@ use crate::State;
 
 #[derive(Deserialize, Debug, Resolve)]
 #[response(Json<HealthCheckResponse>)]
+#[error(StatusCode)]
 pub struct HealthCheck {}
 
 #[derive(Serialize, Debug)]
 pub struct HealthCheckResponse {}
 
 impl Resolve<State> for HealthCheck {
-  async fn resolve(self, _: &State) -> Json<HealthCheckResponse> {
-    Json(HealthCheckResponse {})
+  async fn resolve(self, _: &State) -> Result<Json<HealthCheckResponse>, Self::Error> {
+    Ok(Json(HealthCheckResponse {}))
   }
 }

--- a/examples/axum/src/requests/mod.rs
+++ b/examples/axum/src/requests/mod.rs
@@ -1,3 +1,4 @@
+use axum::http::StatusCode;
 use resolver_api::Resolve;
 use serde::Deserialize;
 
@@ -24,6 +25,7 @@ where
 
 #[derive(Deserialize, Resolve)]
 #[response(Response)]
+#[error(StatusCode)]
 #[args(State)]
 pub enum Request {
   HealthCheck(health_check::HealthCheck),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,12 @@ pub use resolver_api_derive::Resolve;
 
 pub trait HasResponse {
   type Response;
+  type Error;
+
   fn req_type() -> &'static str;
   fn res_type() -> &'static str;
 }
 
 pub trait Resolve<Args = ()>: HasResponse {
-  fn resolve(self, args: &Args) -> impl Future<Output = Self::Response>;
+  fn resolve(self, args: &Args) -> impl Future<Output = Result<Self::Response, Self::Error>>;
 }


### PR DESCRIPTION
Allows top-level responses to be deserializable from `Response` or `Result<Response, Error>`.